### PR TITLE
[Update] mysql-client to mycli

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,6 @@
 FROM gitpod/workspace-go
 
-RUN sudo apt install mysql-client -y
-RUN curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+RUN sudo apt-get install python3-pip -y && \
+    sudo pip install pip -U -q && \
+    sudo pip install mycli -q && \
+    curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh

--- a/Expected-Output.md
+++ b/Expected-Output.md
@@ -85,14 +85,14 @@ buyGoods:
 ```
 /Library/Developer/CommandLineTools/usr/bin/make -C sqldriver
 make mysql build run
-mysql --host 127.0.0.1 --port 4000 -u root<sql/dbinit.sql
+mycli --host 127.0.0.1 --port 4000 -u root --no-warn < sql/dbinit.sql
 go build -o bin/sql-driver-example
 ./bin/sql-driver-example
 getPlayer: {ID:test Coins:1 Goods:1}
 countPlayers: 1920
 print 1 player: {ID:test Coins:1 Goods:1}
-print 2 player: {ID:011603d4-1b76-4871-95e5-cfc0e6a9872f Coins:8081 Goods:7887}
-print 3 player: {ID:52bbc281-81bd-46a6-8f3b-42138e052285 Coins:1847 Goods:4059}
+print 2 player: {ID:87f59982-d3ff-49eb-b720-c3a74fbab215 Coins:8081 Goods:7887}
+print 3 player: {ID:990817b2-074d-4f80-bd03-d28bfc7a35a0 Coins:1847 Goods:4059}
 
 buyGoods:
     => this trade will fail

--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,6 @@ test:
 	$(MAKE) -C gorm all
 	$(MAKE) -C skew all
 	$(MAKE) -C sqldriver all
-	$(MAKE) -C txn all
+	$(MAKE) -C txn pessimistic
+	$(MAKE) -C txn optimistic
 	go test github.com/pingcap-inc/tidb-example-golang/util

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The process is as follows:
 ## Dependency
 
 - [Golang SDK](https://go.dev/)
-- mysql client
+- mycli
 
 ## gorm example
 

--- a/batch/update/Makefile
+++ b/batch/update/Makefile
@@ -19,7 +19,7 @@ all:
 
 prepare:
 	~/.tiup/bin/tiup demo bookshop prepare --drop-tables
-	mysql --host 127.0.0.1 --port 4000 -u root<add_attr_ten_point.sql
+	mycli --host 127.0.0.1 --port 4000 -u root --no-warn < add_attr_ten_point.sql
 
 build:
 	go build -o bin/batch-update

--- a/skew/Makefile
+++ b/skew/Makefile
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: all build run
+.PHONY: all prepare build run
 
 all:
-	make build run
+	make prepare build run
+
+prepare:
+	mycli --host 127.0.0.1 --port 4000 -u root -e "TRUNCATE test.doctors"
 
 build:
 	go build -o bin/write-skew

--- a/sqldriver/Makefile
+++ b/sqldriver/Makefile
@@ -19,7 +19,7 @@ all:
 	make mysql build run
 
 mysql:
-	mysql --host 127.0.0.1 --port 4000 -u root<sql/dbinit.sql
+	mycli --host 127.0.0.1 --port 4000 -u root --no-warn < sql/dbinit.sql
 
 build:
 	go build -o bin/sql-driver-example


### PR DESCRIPTION
- Usage: `mysql-client` to `mycli`.
- Dockerfile: `mysql-client` to `mycli`.